### PR TITLE
Add Google Analytics tracking code to splash page

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/png" href="/images/favicon.png">
     <title>HASHGRID NETWORKS</title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8D2LWJRBF6"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8D2LWJRBF6');
+    </script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap');
 


### PR DESCRIPTION
This PR adds Google Analytics tracking code to the splash page for better user analytics and insights.